### PR TITLE
Some tweaks to improve build speeds 2x

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,24 @@
+# Rename this file to `config.toml` to enable "fast build" configuration. Please read the notes below.
+# NOTE: For maximum performance, build using a nightly compiler
+# If you are using rust stable, remove the "-Zshare-generics=y" below.
+[target.x86_64-unknown-linux-gnu]
+linker = "/usr/bin/clang"
+rustflags = ["-Clink-arg=-fuse-ld=lld", "-Zshare-generics=y"]
+
+# NOTE: you must manually install https://github.com/michaeleisel/zld on mac. you can easily do this with the "brew" package manager:
+# `brew install michaeleisel/zld/zld`
+[target.x86_64-apple-darwin]
+rustflags = [
+  "-C",
+  "link-arg=-fuse-ld=/usr/local/bin/zld",
+  "-Zshare-generics=y",
+  "-Zrun-dsymutil=no"
+]
+
+[target.x86_64-pc-windows-msvc]
+linker = "rust-lld.exe"
+rustflags = ["-Zshare-generics=y"]
+# Optional: Uncommenting the following improves compile times, but reduces the amount of debug info to 'line number tables only'
+# In most cases the gains are negligible, but if you are on macos and have slow compile times you should see significant gains.
+#[profile.dev]
+#debug = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,6 @@ publish = false
 iced = { version = "0.2.0", features = ["debug"] }
 iced_native = "0.3"
 env_logger = "0.8"
+
+[build]
+incremental = true

--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ Then run in a sort of live-reload mode with this command:
 
 `cargo watch -w src/*.rs -x run`
 
+See also this section on Enabling Fast Compiles for your system:
+
+<https://bevyengine.org/learn/book/getting-started/setup/#enable-fast-compiles-optional>
+
+Then run: `rustup override set nightly` for nightly builds for just this project.
+
 ## Docs
 
 For convenience, here are some links to the iced docs:


### PR DESCRIPTION
These changes, when on a properly configured system, reliably improve build speeds by 2x on an 8-core Ryzen 7 running Arch Linux. Links for configuration on other systems is also documented.

Before:

![Screenshot from 2020-12-13 13-59-27](https://user-images.githubusercontent.com/285690/102023919-cdd40d80-3d4b-11eb-839e-3c744f226d70.png)

After:

![Screenshot from 2020-12-13 13-59-16](https://user-images.githubusercontent.com/285690/102023922-d3c9ee80-3d4b-11eb-836c-6f4336d98d0f.png)

(These were for small, single line changes.)

This was done by following recommendations made on this thread:

https://github.com/hecrj/iced/issues/638

And on this page:

https://bevyengine.org/learn/book/getting-started/setup/#enable-fast-compiles-optional